### PR TITLE
Added Work Item Revision Replay Migration.

### DIFF
--- a/src/VstsSyncMigrator.Console/VstsSyncMigrator.Console.csproj
+++ b/src/VstsSyncMigrator.Console/VstsSyncMigrator.Console.csproj
@@ -240,7 +240,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VstsSyncMigrator.Core\VstsSyncMigrator.Core.csproj">
-      <Project>{68baf6ba-2bc0-48d0-b892-1d9f93d7003a}</Project>
+      <Project>{68BAF6BA-2BC0-48D0-B892-1D9F93D7003A}</Project>
       <Name>VstsSyncMigrator.Core</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/EngineConfiguration.cs
@@ -106,6 +106,7 @@ namespace VstsSyncMigrator.Engine.Configuration
             };
             ec.Processors = new List<ITfsProcessingConfig>();
             ec.Processors.Add(new WorkItemMigrationConfig() { Enabled = false, UpdateCreatedBy=true, PrefixProjectToNodes = true, UpdateCreatedDate=true, UpdateSoureReflectedId=true, QueryBit = @"AND [TfsMigrationTool.ReflectedWorkItemId] = '' AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] IN ('Shared Steps', 'Shared Parameter', 'Test Case', 'Requirement', 'Task', 'User Story', 'Bug')" });
+            ec.Processors.Add(new WorkItemRevisionReplayMigrationConfig() { Enabled = false, UpdateCreatedBy=true, PrefixProjectToNodes = true, UpdateCreatedDate=true, UpdateSoureReflectedId=true, QueryBit = @"AND [TfsMigrationTool.ReflectedWorkItemId] = '' AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] IN ('Shared Steps', 'Shared Parameter', 'Test Case', 'Requirement', 'Task', 'User Story', 'Bug')" });
             ec.Processors.Add(new WorkItemUpdateConfig() { Enabled = false, QueryBit = @"AND [TfsMigrationTool.ReflectedWorkItemId] = '' AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] IN ('Shared Steps', 'Shared Parameter', 'Test Case', 'Requirement', 'Task', 'User Story', 'Bug')" });
             ec.Processors.Add(new NodeStructuresMigrationConfig() { Enabled = false });
             ec.Processors.Add(new LinkMigrationConfig() { Enabled = false, QueryBit= @"AND ([System.ExternalLinkCount] > 0 OR [System.RelatedLinkCount] > 0)" });

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemRevisionReplayMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemRevisionReplayMigrationConfig.cs
@@ -1,17 +1,22 @@
-﻿using System;
+using System;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
-    public class WorkItemMigrationConfig : ITfsProcessingConfig
+    public class WorkItemRevisionReplayMigrationConfig : ITfsProcessingConfig
     {
+        public bool Enabled { get; set; }
         public bool PrefixProjectToNodes { get; set; }
         public bool UpdateCreatedDate { get; set; }
         public bool UpdateCreatedBy { get; set; }
         public bool UpdateSoureReflectedId { get; set; }
+        public Type Processor
+        {
+            get
+            {
+                return typeof(WorkItemRevisionReplayMigrationContext);
+            }
+        }
 
         public string QueryBit { get; set; }
-        public bool Enabled { get; set; }
-
-        public Type Processor => typeof(WorkItemMigrationContext);
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
@@ -148,6 +148,10 @@ namespace VstsSyncMigrator.Engine
             return newFound[0];
         }
 
+        public WorkItem GetRevision(WorkItem workItem, int revision)
+        {
+            return Store.GetWorkItem(workItem.Id, revision);
+        }
 
     }
 }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/MigrationContextBase.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/MigrationContextBase.cs
@@ -1,88 +1,82 @@
-﻿using Microsoft.ApplicationInsights;
-using Microsoft.TeamFoundation.WorkItemTracking.Client;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Net;
 using System.Text.RegularExpressions;
+
 using VstsSyncMigrator.Engine.Configuration.Processing;
 
 namespace VstsSyncMigrator.Engine
 {
     public abstract class MigrationContextBase : ITfsProcessingContext
     {
-        internal MigrationEngine me;
-        ProcessingStatus status = ProcessingStatus.None;
+        internal readonly MigrationEngine me;
 
 
-        public MigrationContextBase(MigrationEngine me, ITfsProcessingConfig config)
+        protected MigrationContextBase(MigrationEngine me, ITfsProcessingConfig config)
         {
             this.me = me;
         }
 
         public abstract string Name { get; }
 
-        public ProcessingStatus Status
-        {
-            get
-            {
-                return status;
-            }
-        }
+        public ProcessingStatus Status { get; private set; } = ProcessingStatus.None;
 
         public void Execute()
         {
             Telemetry.Current.TrackEvent("MigrationContextExecute",
-                      new Dictionary<string, string> {
-                          { "Name", Name},
-                          { "Target Project", me.Target.Name},
-                          { "Target Collection", me.Target.Collection.Name },
-                          { "Source Project", me.Source.Name},
-                          { "Source Collection", me.Source.Collection.Name }
-                      });
-            Trace.TraceInformation(string.Format(" Migration Context Start {0} ", Name));
-            Stopwatch executeTimer = new Stopwatch();
+                new Dictionary<string, string>
+                {
+                    {"Name", Name},
+                    {"Target Project", me.Target.Name},
+                    {"Target Collection", me.Target.Collection.Name},
+                    {"Source Project", me.Source.Name},
+                    {"Source Collection", me.Source.Collection.Name}
+                });
+            Trace.TraceInformation(" Migration Context Start {0} ", Name);
+            var executeTimer = new Stopwatch();
             executeTimer.Start();
             //////////////////////////////////////////////////
             try
             {
-                status = ProcessingStatus.Running;
+                Status = ProcessingStatus.Running;
                 InternalExecute();
-                status = ProcessingStatus.Complete;
+                Status = ProcessingStatus.Complete;
                 executeTimer.Stop();
                 Telemetry.Current.TrackEvent("MigrationContextComplete",
-                    new Dictionary<string, string> {
-                        { "Name", Name},
-                        { "Target Project", me.Target.Name},
-                        { "Target Collection", me.Target.Collection.Name },
-                        { "Source Project", me.Source.Name},
-                        { "Source Collection", me.Source.Collection.Name },
-                        { "Status", Status.ToString() }
+                    new Dictionary<string, string>
+                    {
+                        {"Name", Name},
+                        {"Target Project", me.Target.Name},
+                        {"Target Collection", me.Target.Collection.Name},
+                        {"Source Project", me.Source.Name},
+                        {"Source Collection", me.Source.Collection.Name},
+                        {"Status", Status.ToString()}
                     },
-                    new Dictionary<string, double> {
-                        { "MigrationContextTime", executeTimer.ElapsedMilliseconds }
+                    new Dictionary<string, double>
+                    {
+                        {"MigrationContextTime", executeTimer.ElapsedMilliseconds}
                     });
-                Trace.TraceInformation(string.Format(" Migration Context Complete {0} ", Name));
+                Trace.TraceInformation(" Migration Context Complete {0} ", Name);
             }
             catch (Exception ex)
             {
-                status = ProcessingStatus.Failed;
+                Status = ProcessingStatus.Failed;
                 executeTimer.Stop();
                 Telemetry.Current.TrackException(ex,
-                      new Dictionary<string, string> {
-                          { "Name", Name},
-                          { "Target Project", me.Target.Name},
-                          { "Target Collection", me.Target.Collection.Name },
-                          { "Source Project", me.Source.Name},
-                          { "Source Collection", me.Source.Collection.Name },
-                          { "Status", Status.ToString() }
-                      },
-                      new Dictionary<string, double> {
-                            { "MigrationContextTime", executeTimer.ElapsedMilliseconds }
-                      });
-                Trace.TraceWarning(string.Format("  [EXCEPTION] {0}", ex.Message));
+                    new Dictionary<string, string>
+                    {
+                        {"Name", Name},
+                        {"Target Project", me.Target.Name},
+                        {"Target Collection", me.Target.Collection.Name},
+                        {"Source Project", me.Source.Name},
+                        {"Source Collection", me.Source.Collection.Name},
+                        {"Status", Status.ToString()}
+                    },
+                    new Dictionary<string, double>
+                    {
+                        {"MigrationContextTime", executeTimer.ElapsedMilliseconds}
+                    });
+                Trace.TraceWarning("  [EXCEPTION] {0}", ex.Message);
                 throw ex;
             }
         }
@@ -100,19 +94,14 @@ namespace VstsSyncMigrator.Engine
 
             //// Output = [targetTeamProject]\[sourceTeamProject]\[AreaPath]
             //return r.Replace(input, target.Name, 1);
-
         }
 
         internal string ReplaceFirstInstanceOf(string input)
         {
             //input = [sourceTeamProject]\[AreaPath]
-            Regex r = new Regex(me.Source.Name, RegexOptions.IgnoreCase);
+            var r = new Regex(me.Source.Name, RegexOptions.IgnoreCase);
             //// Output = [targetTeamProject]\[sourceTeamProject]\[AreaPath]
             return r.Replace(input, me.Target.Name, 1);
-
         }
     }
-
-
-
 }

--- a/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/MigrationContext/WorkItemRevisionReplayMigrationContext.cs
@@ -1,0 +1,297 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+using Microsoft.TeamFoundation.WorkItemTracking.Client;
+
+using VstsSyncMigrator.Engine.Configuration.Processing;
+
+namespace VstsSyncMigrator.Engine
+{
+    public class WorkItemRevisionReplayMigrationContext : MigrationContextBase
+    {
+        private readonly WorkItemRevisionReplayMigrationConfig _config;
+        List<String> _ignore;
+
+        public WorkItemRevisionReplayMigrationContext(MigrationEngine me, WorkItemRevisionReplayMigrationConfig config)
+            : base(me, config)
+        {
+            _config = config;
+            PopulateIgnoreList();
+        }
+
+        private void PopulateIgnoreList()
+        {
+            _ignore = new List<string>
+            {
+                "System.Rev",
+                "System.AreaId",
+                "System.IterationId",
+                "System.Id",
+                "System.RevisedDate",
+                "System.AuthorizedAs",
+                "System.AttachedFileCount",
+                "System.TeamProject",
+                "System.NodeName",
+                "System.RelatedLinkCount",
+                "System.WorkItemType",
+                "Microsoft.VSTS.Common.ActivatedDate",
+                "Microsoft.VSTS.Common.ResolvedDate",
+                "Microsoft.VSTS.Common.ClosedDate",
+                "Microsoft.VSTS.Common.StateChangeDate",
+                "System.ExternalLinkCount",
+                "System.HyperLinkCount",
+                "System.Watermark",
+                "System.AuthorizedDate",
+                "System.BoardColumn",
+                "System.BoardColumnDone",
+                "System.BoardLane",
+                "SLB.SWT.DateOfClientFeedback"
+            };
+        }
+
+        public override string Name => "WorkItemRevisionReplayMigrationContext";
+
+        internal override void InternalExecute()
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            //////////////////////////////////////////////////
+            var sourceStore = new WorkItemStoreContext(me.Source, WorkItemStoreFlags.BypassRules);
+            var tfsqc = new TfsQueryContext(sourceStore);
+            tfsqc.AddParameter("TeamProject", me.Source.Name);
+            tfsqc.Query =
+                string.Format(
+                    @"SELECT [System.Id], [System.Tags] FROM WorkItems WHERE [System.TeamProject] = @TeamProject {0} ORDER BY [System.ChangedDate] desc",
+                    _config.QueryBit);
+            var sourceWorkItems = tfsqc.Execute();
+            Trace.WriteLine($"Replay all revisions of {sourceWorkItems.Count} work items?", Name);
+
+            //////////////////////////////////////////////////
+            var targetStore = new WorkItemStoreContext(me.Target, WorkItemStoreFlags.BypassRules);
+            var destProject = targetStore.GetProject();
+            Trace.WriteLine($"Found target project as {destProject.Name}", Name);
+
+            var current = sourceWorkItems.Count;
+            var count = 0;
+            long elapsedms = 0;
+
+            foreach (WorkItem sourceWorkItem in sourceWorkItems)
+            {
+                var witstopwatch = new Stopwatch();
+                witstopwatch.Start();
+                var targetFound = targetStore.FindReflectedWorkItem(sourceWorkItem, me.ReflectedWorkItemIdFieldName, false);
+                Trace.WriteLine($"{current} - Migrating: {sourceWorkItem.Id} - {sourceWorkItem.Type.Name}", Name);
+
+                if (targetFound == null)
+                {
+                    ReplayRevisions(sourceWorkItem, destProject, sourceStore, current, targetStore);
+                }
+                else
+                {
+                    Console.WriteLine("...Exists");
+                }
+
+                sourceWorkItem.Close();
+                witstopwatch.Stop();
+                elapsedms = elapsedms + witstopwatch.ElapsedMilliseconds;
+                current--;
+                count++;
+                var average = new TimeSpan(0, 0, 0, 0, (int) (elapsedms / count));
+                var remaining = new TimeSpan(0, 0, 0, 0, (int) (average.TotalMilliseconds * current));
+                Trace.WriteLine(
+                    string.Format("Average time of {0} per work item and {1} estimated to completion",
+                        string.Format(@"{0:s\:fff} seconds", average),
+                        string.Format(@"{0:%h} hours {0:%m} minutes {0:s\:fff} seconds", remaining)), Name);
+                Trace.Flush();
+            }
+            //////////////////////////////////////////////////
+            stopwatch.Stop();
+
+            Console.WriteLine(@"DONE in {0:%h} hours {0:%m} minutes {0:s\:fff} seconds", stopwatch.Elapsed);
+        }
+
+        private void ReplayRevisions(WorkItem sourceWorkItem, Project destProject, WorkItemStoreContext sourceStore,
+            int current,
+            WorkItemStoreContext targetStore)
+        {
+            WorkItem newwit = null;
+
+            try
+            {
+                // just to make sure, we replay the events in the same order as they appeared
+                // maybe, the Revisions collection is not sorted according to the actual Revision number
+                var sortedRevisions = sourceWorkItem.Revisions.Cast<Revision>().Select(x =>
+                        new
+                        {
+                            Number =  Convert.ToInt32(x.Fields["System.Rev"].Value)
+                        }
+                    )
+                    .OrderBy(x => x.Number)
+                    .ToList();
+
+                Trace.WriteLine($"...Replaying {sourceWorkItem.Revisions.Count} revisions of work item {sourceWorkItem.Id}", Name);
+
+                foreach (var revision in sortedRevisions)
+                {
+                    var currentRevisionWorkItem = sourceStore.GetRevision(sourceWorkItem, revision.Number);
+
+                    // Decide on WIT
+                    if (me.WorkItemTypeDefinitions.ContainsKey(currentRevisionWorkItem.Type.Name))
+                    {
+                        var destType =
+                            me.WorkItemTypeDefinitions[currentRevisionWorkItem.Type.Name].Map(currentRevisionWorkItem);
+
+                        if (newwit == null)
+                        {
+                            var newWorkItemstartTime = DateTime.UtcNow;
+                            var newWorkItemTimer = new Stopwatch();
+                            newwit = destProject.WorkItemTypes[destType].NewWorkItem();
+                            newWorkItemTimer.Stop();
+                            Telemetry.Current.TrackDependency("TeamService", "NewWorkItem", newWorkItemstartTime,
+                                newWorkItemTimer.Elapsed, true);
+                            Trace.WriteLine(
+                                string.Format("Dependency: {0} - {1} - {2} - {3} - {4}", "TeamService", "NewWorkItem",
+                                    newWorkItemstartTime, newWorkItemTimer.Elapsed, true), Name);
+                        }
+
+                        PopulateWorkItem(currentRevisionWorkItem, newwit, destType);
+                        me.ApplyFieldMappings(currentRevisionWorkItem, newwit);
+                        var fails = newwit.Validate();
+
+                        foreach (Field f in fails)
+                        {
+                            Trace.WriteLine(
+                                $"{current} - Invalid: {currentRevisionWorkItem.Id}-{currentRevisionWorkItem.Type.Name}-{f.ReferenceName}",
+                                Name);
+                        }
+
+                        if (_config.UpdateCreatedDate)
+                            newwit.Fields["System.CreatedDate"].Value =
+                                currentRevisionWorkItem.Fields["System.CreatedDate"].Value;
+                        if (_config.UpdateCreatedBy)
+                            newwit.Fields["System.CreatedBy"].Value =
+                                currentRevisionWorkItem.Fields["System.CreatedBy"].Value;
+
+                        newwit.Save();
+                        Trace.WriteLine(
+                            $" ...Saved as {newwit.Id}. Replayed revision {revision.Number} of {sourceWorkItem.Revisions.Count}",
+                            Name);
+                    }
+                    else
+                    {
+                        Trace.WriteLine("...not supported", Name);
+                        break;
+                    }
+                }
+
+                if (newwit != null)
+                {
+                    if (newwit.Fields.Contains(me.ReflectedWorkItemIdFieldName))
+                    {
+                        newwit.Fields[me.ReflectedWorkItemIdFieldName].Value =
+                            sourceStore.CreateReflectedWorkItemId(sourceWorkItem);
+                    }
+
+                    var history = new StringBuilder();
+                    history.Append(
+                        "Migrated by <a href='http://nkdagility.com'>naked Agility Limited's</a> open source <a href='https://github.com/nkdAgility/VstsMigrator'>VSTS/TFS Migrator</a>.");
+                    newwit.History = history.ToString();
+
+                    newwit.Save();
+                    newwit.Close();
+                    Trace.WriteLine($"...Saved as {newwit.Id}", Name);
+
+                    if (sourceWorkItem.Fields.Contains(me.ReflectedWorkItemIdFieldName) &&
+                        _config.UpdateSoureReflectedId)
+                    {
+                        sourceWorkItem.Fields[me.ReflectedWorkItemIdFieldName].Value =
+                            targetStore.CreateReflectedWorkItemId(newwit);
+                        sourceWorkItem.Save();
+                        Trace.WriteLine($"...and Source Updated {sourceWorkItem.Id}", Name);
+                    }
+
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine("...FAILED to Save", Name);
+
+                if (newwit != null)
+                {
+                    foreach (Field f in newwit.Fields)
+                        Trace.WriteLine($"{f.ReferenceName} | {f.Value}", Name);
+                }
+                Trace.WriteLine(ex.ToString(), Name);
+            }
+        }
+
+        private void PopulateWorkItem(WorkItem oldWi, WorkItem newwit, string destType)
+        {
+            var newWorkItemstartTime = DateTime.UtcNow;
+            var fieldMappingTimer = new Stopwatch();
+            
+            Trace.Write("... Building ", Name);
+            
+            newwit.Title = oldWi.Title;
+            newwit.State = oldWi.State;
+            newwit.Reason = oldWi.Reason;
+
+            foreach (Field f in oldWi.Fields)
+            {
+                if (newwit.Fields.Contains(f.ReferenceName) && !_ignore.Contains(f.ReferenceName))
+                {
+                    newwit.Fields[f.ReferenceName].Value = oldWi.Fields[f.ReferenceName].Value;
+                }
+            }
+
+            if (_config.PrefixProjectToNodes)
+            {
+                newwit.AreaPath = $@"{newwit.Project.Name}\{oldWi.AreaPath}";
+                newwit.IterationPath = $@"{newwit.Project.Name}\{oldWi.IterationPath}";
+            }
+            else
+            {
+                var regex = new Regex(Regex.Escape(oldWi.Project.Name));
+                newwit.AreaPath = regex.Replace(oldWi.AreaPath, newwit.Project.Name, 1);
+                newwit.IterationPath = regex.Replace(oldWi.IterationPath, newwit.Project.Name, 1);
+            }
+
+            switch (destType)
+            {
+                case "Test Case":
+                    newwit.Fields["Microsoft.VSTS.TCM.Steps"].Value = oldWi.Fields["Microsoft.VSTS.TCM.Steps"].Value;
+                    newwit.Fields["Microsoft.VSTS.Common.Priority"].Value =
+                        oldWi.Fields["Microsoft.VSTS.Common.Priority"].Value;
+                    break;
+            }
+            
+            if (newwit.Fields.Contains("Microsoft.VSTS.Common.BacklogPriority")
+                && newwit.Fields["Microsoft.VSTS.Common.BacklogPriority"].Value != null
+                && !IsNumeric(newwit.Fields["Microsoft.VSTS.Common.BacklogPriority"].Value.ToString(),
+                    NumberStyles.Any))
+                newwit.Fields["Microsoft.VSTS.Common.BacklogPriority"].Value = 10;
+
+            var description = new StringBuilder();
+            description.Append(oldWi.Description);
+            newwit.Description = description.ToString();
+
+            Trace.WriteLine("...build complete", Name);
+            fieldMappingTimer.Stop();
+            Telemetry.Current.TrackMetric("FieldMappingTime", fieldMappingTimer.ElapsedMilliseconds);
+            Trace.WriteLine(
+                $"FieldMapOnNewWorkItem: {newWorkItemstartTime} - {fieldMappingTimer.Elapsed.ToString("c")}", Name);
+        }
+        
+        private static bool IsNumeric(string val, NumberStyles numberStyle)
+        {
+            double result;
+            return double.TryParse(val, numberStyle,
+                CultureInfo.CurrentCulture, out result);
+        }
+    }
+}

--- a/src/VstsSyncMigrator.Core/VstsSyncMigrator.Core.csproj
+++ b/src/VstsSyncMigrator.Core/VstsSyncMigrator.Core.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Configuration\Processing\WorkItemQueryMigrationConfig.cs" />
     <Compile Include="Configuration\Processing\FixGitCommitLinksConfig.cs" />
     <Compile Include="Configuration\Processing\TeamMigrationConfig.cs" />
+    <Compile Include="Configuration\Processing\WorkItemRevisionReplayMigrationConfig.cs" />
     <Compile Include="Configuration\Processing\WorkItemUpdateAreasAsTagsConfig.cs" />
     <Compile Include="Configuration\Processing\FakeProcessorConfig.cs" />
     <Compile Include="Configuration\Processing\ExportProfilePictureFromADConfig.cs" />
@@ -267,6 +268,7 @@
     <Compile Include="Execution\FieldMaps\IFieldMap.cs" />
     <Compile Include="Execution\ComponentContext\TestManagementContext.cs" />
     <Compile Include="Execution\FieldMaps\FieldToTagFieldMap.cs" />
+    <Compile Include="Execution\MigrationContext\WorkItemRevisionReplayMigrationContext.cs" />
     <Compile Include="Execution\MigrationContext\WorkItemQueryMigrationContext.cs" />
     <Compile Include="Execution\MigrationContext\LinkMigrationContext.cs" />
     <Compile Include="Execution\MigrationContext\AttachementExportMigrationContext.cs" />


### PR DESCRIPTION
This work item migration context will not directly migrate over the last revision of the source work item, but it will migrate over all revisions from the source item, thus resulting in the very same history and revision graph on the new target system.