### PR TITLE
Fixing documentation for work item revisions replay context.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,7 +105,15 @@ The global configuration created by the `init` command look like this:
 			"UpdateCreatedBy": true,
 			"UpdateSoureReflectedId": true,
 			"QueryBit": "AND [TfsMigrationTool.ReflectedWorkItemId] = '' AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] IN ('Shared Steps', 'Shared Parameter', 'Test Case', 'Requirement', 'Task', 'User Story', 'Bug')"
-		}, {
+		},{		
+			"ObjectType": "VstsSyncMigrator.Engine.Configuration.Processing.WorkItemRevisionReplayMigrationConfig",
+			"Enabled": false,
+			"PrefixProjectToNodes": false,
+			"UpdateCreatedDate": true,
+			"UpdateCreatedBy": true,
+			"UpdateSoureReflectedId": false,
+			"QueryBit": "AND [TfsMigrationTool.ReflectedWorkItemId] = '' AND [System.Tags] Contains 'Xyz'"
+	    },{
 			"ObjectType": "VstsSyncMigrator.Engine.Configuration.Processing.WorkItemUpdateConfig",
 			"WhatIf": false,
 			"Enabled": false,

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,9 +47,12 @@ There are other processors that can be used to migrate, or process, different so
 
 Most of these processors need to be run in order. If you try to migrate work items before you have migrated Area and Iterations then ***bang*** you need to go back.
 
+Note: **WorkItemMigrationContext** and **WorkItemRevisionReplayMigrationContext** are exclusive, you can only run either of the options, but not both!
+
 ##### Work Items
 1. **NodeStructuresMigrationContext** - Moves over the structure of area and iteration paths, you have the option to inject a new root node by setting the `PrefixProjectToNodes` property. 
 1. **WorkItemMigrationContext** - **The work horse...** push the tip from one location to another while maintaining context. Make sure that you add a ReflectedWorkItemID and you can restart the service at any time...
+1. **WorkItemRevisionReplayMigrationContext** - **The second work horse...** push all revisions of work items from one location to another while maintaining context. Make sure that you add a ReflectedWorkItemID and you can restart the service at any time. This context will move replay all the revisions of work items in the source system in the exact same order on the target system, thus resulting in the very same history and state graph on the target system.
 1. **AttachementExportMigrationContext** - Exports all work items attachments to the migration machine. This is used in partnership with the **AttachmentImportMigrationContext**   
 1. **AttachementImportMigrationContext** - Imports all work items attachments from the migration machine. This is used in partnership with the **AttachementExportMigrationContext**
 1. **LinkMigrationContext** - Migrates all the work item links, both between work items and external links.

--- a/docs/usage/command-line.md
+++ b/docs/usage/command-line.md
@@ -100,7 +100,15 @@ Note that:
 			"UpdateCreatedBy": true,
 			"UpdateSoureReflectedId": true,
 			"QueryBit": "AND [TfsMigrationTool.ReflectedWorkItemId] = '' AND  [Microsoft.VSTS.Common.ClosedDate] = '' AND [System.WorkItemType] IN ('Shared Steps', 'Shared Parameter', 'Test Case', 'Requirement', 'Task', 'User Story', 'Bug')"
-		}, {
+		},{		
+			"ObjectType": "VstsSyncMigrator.Engine.Configuration.Processing.WorkItemRevisionReplayMigrationConfig",
+			"Enabled": false,
+			"PrefixProjectToNodes": false,
+			"UpdateCreatedDate": true,
+			"UpdateCreatedBy": true,
+			"UpdateSoureReflectedId": false,
+			"QueryBit": "AND [TfsMigrationTool.ReflectedWorkItemId] = '' AND [System.Tags] Contains 'Xyz'"
+	    },{
 			"ObjectType": "VstsSyncMigrator.Engine.Configuration.Processing.WorkItemUpdateConfig",
 			"WhatIf": false,
 			"Enabled": false,

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/AttachementExportMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/AttachementExportMigrationConfig.cs
@@ -1,24 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
     public class AttachementExportMigrationConfig : ITfsProcessingConfig
     {
-        public bool Enabled { get; set; }
         public string QueryBit { get; set; }
+        public bool Enabled { get; set; }
 
         public Type Processor
         {
-            get
-            {
-                return typeof(AttachementExportMigrationContext);
-            }
+            get { return typeof(AttachementExportMigrationContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/AttachementImportMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/AttachementImportMigrationConfig.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
@@ -12,12 +9,13 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
 
         public Type Processor
         {
-            get
-            {
-                return typeof(AttachementImportMigrationContext);
-            }
+            get { return typeof(AttachementImportMigrationContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/ExportProfilePictureFromADConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/ExportProfilePictureFromADConfig.cs
@@ -1,28 +1,25 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
     public class ExportProfilePictureFromADConfig : ITfsProcessingConfig
     {
-        public bool Enabled { get; set; }
-
         public string Domain { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
         public string PictureEmpIDFormat { get; set; }
+        public bool Enabled { get; set; }
 
         public Type Processor
         {
-            get
-            {
-                return typeof(ExportProfilePictureFromADContext);
-            }
+            get { return typeof(ExportProfilePictureFromADContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/FakeProcessorConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/FakeProcessorConfig.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
@@ -12,12 +9,13 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
 
         public Type Processor
         {
-            get
-            {
-                return typeof(FakeProcessor);
-            }
+            get { return typeof(FakeProcessor); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/FixGitCommitLinksConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/FixGitCommitLinksConfig.cs
@@ -1,21 +1,22 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
     public class FixGitCommitLinksConfig : ITfsProcessingConfig
     {
-        public bool Enabled { get; set; }
-
         public string TargetRepository { get; set; }
+        public bool Enabled { get; set; }
 
         public Type Processor
         {
-            get
-            {
-                return typeof(FixGitCommitLinks);
-            }
+            get { return typeof(FixGitCommitLinks); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/ITfsProcessingConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/ITfsProcessingConfig.cs
@@ -12,6 +12,12 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
         bool Enabled { get; set; }
         [JsonIgnoreAttribute]
         Type Processor { get; }
-
+        
+        /// <summary>
+        /// Indicates, if this processor can be added to the list of current processors or not.
+        /// Some processors are not compatible with each other.
+        /// </summary>
+        /// <param name="otherProcessors">List of already configured processors.</param>
+        bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors);
     }
 }

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/ImportProfilePictureConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/ImportProfilePictureConfig.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
@@ -12,12 +9,13 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
 
         public Type Processor
         {
-            get
-            {
-                return typeof(ImportProfilePictureContext);
-            }
+            get { return typeof(ImportProfilePictureContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/LinkMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/LinkMigrationConfig.cs
@@ -1,24 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
     public class LinkMigrationConfig : ITfsProcessingConfig
     {
-        public bool Enabled { get; set; }
         public string QueryBit { get; set; }
+        public bool Enabled { get; set; }
 
         public Type Processor
         {
-            get
-            {
-                return typeof(LinkMigrationContext);
-            }
+            get { return typeof(LinkMigrationContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/NodeStructuresMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/NodeStructuresMigrationConfig.cs
@@ -1,24 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
     public class NodeStructuresMigrationConfig : ITfsProcessingConfig
     {
-        public bool Enabled { get; set; }
         public bool PrefixProjectToNodes { get; set; }
+        public bool Enabled { get; set; }
 
         public Type Processor
         {
-            get
-            {
-                return typeof(NodeStructuresMigrationContext);
-            }
+            get { return typeof(NodeStructuresMigrationContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/TeamMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/TeamMigrationConfig.cs
@@ -1,22 +1,21 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
     public class TeamMigrationConfig : ITfsProcessingConfig
     {
         public bool Enabled { get; set; }
+
         public Type Processor
         {
-            get
-            {
-                return typeof(TeamMigrationContext);
-            }
+            get { return typeof(TeamMigrationContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/TestConfigurationsMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/TestConfigurationsMigrationConfig.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
@@ -12,12 +9,13 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
 
         public Type Processor
         {
-            get
-            {
-                return typeof(TestConfigurationsMigrationContext);
-            }
+            get { return typeof(TestConfigurationsMigrationContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/TestPlansAndSuitsMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/TestPlansAndSuitsMigrationConfig.cs
@@ -1,24 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
     public class TestPlansAndSuitsMigrationConfig : ITfsProcessingConfig
     {
-        public bool Enabled { get; set; }
         public bool PrefixProjectToNodes { get; set; }
+        public bool Enabled { get; set; }
 
         public Type Processor
         {
-            get
-            {
-                return typeof(TestPlansAndSuitsMigrationContext);
-            }
+            get { return typeof(TestPlansAndSuitsMigrationContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/TestRunsMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/TestRunsMigrationConfig.cs
@@ -1,24 +1,26 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
     public class TestRunsMigrationConfig : ITfsProcessingConfig
     {
+        public string Status
+        {
+            get { return "Experimental"; }
+        }
+
         public bool Enabled { get; set; }
-        public string Status { get { return "Experimental"; } }
 
         public Type Processor
         {
-            get
-            {
-                return typeof(TestRunsMigrationContext);
-            }
+            get { return typeof(TestRunsMigrationContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/TestVeriablesMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/TestVeriablesMigrationConfig.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
@@ -12,12 +9,13 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
 
         public Type Processor
         {
-            get
-            {
-                return typeof(TestVeriablesMigrationContext);
-            }
+            get { return typeof(TestVeriablesMigrationContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemDeleteConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemDeleteConfig.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
@@ -12,12 +9,13 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
 
         public Type Processor
         {
-            get
-            {
-                return typeof(WorkItemDelete);
-            }
+            get { return typeof(WorkItemDelete); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemMigrationConfig.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
@@ -13,5 +16,12 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
         public bool Enabled { get; set; }
 
         public Type Processor => typeof(WorkItemMigrationContext);
+
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            Trace.WriteLine($"Note: {GetType().Name} is not compatible with {typeof(WorkItemRevisionReplayMigrationConfig).Name}");
+            return !otherProcessors.Any(x => x is WorkItemRevisionReplayMigrationConfig);
+        }
     }
 }

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemPostProcessingConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemPostProcessingConfig.cs
@@ -1,23 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
     public class WorkItemPostProcessingConfig : ITfsProcessingConfig
     {
-        public bool Enabled { get; set; }
         public string QueryBit { get; set; }
         public IList<int> WorkItemIDs { get; set; }
+        public bool Enabled { get; set; }
+
         public Type Processor
         {
-            get
-            {
-                return typeof(WorkItemPostProcessingContext);
-            }
+            get { return typeof(WorkItemPostProcessingContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemQueryMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemQueryMigrationConfig.cs
@@ -1,51 +1,43 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
     public class WorkItemQueryMigrationConfig : ITfsProcessingConfig
     {
         /// <summary>
-        /// Is this processor enabled
-        /// </summary>
-        public bool Enabled { get; set; }
-
-        /// <summary>
-        /// Do we add the source project name into the folder path
-        /// </summary>
-        public bool PrefixProjectToNodes { get; set; }
-
-        /// <summary>
-        ///  The name of the shared folder, setting the default name
+        ///     The name of the shared folder, setting the default name
         /// </summary>
         private string sharedFolderName = "Shared Queries";
 
         /// <summary>
-        ///  The name of the shared folder, made a parameter incase it every needs to be edited
+        ///     Do we add the source project name into the folder path
+        /// </summary>
+        public bool PrefixProjectToNodes { get; set; }
+
+        /// <summary>
+        ///     The name of the shared folder, made a parameter incase it every needs to be edited
         /// </summary>
         public string SharedFolderName
         {
-            get
-            {
-                return this.sharedFolderName;
-            }
-            set
-            {
-                this.sharedFolderName = value;
-            }
+            get { return sharedFolderName; }
+            set { sharedFolderName = value; }
         }
+
+        /// <summary>
+        ///     Is this processor enabled
+        /// </summary>
+        public bool Enabled { get; set; }
 
         public Type Processor
         {
-            get
-            {
-                return typeof(WorkItemQueryMigrationContext);
-            }
+            get { return typeof(WorkItemQueryMigrationContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
 }
-

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemRevisionReplayMigrationConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemRevisionReplayMigrationConfig.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
@@ -18,5 +21,12 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
         }
 
         public string QueryBit { get; set; }
+
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            Trace.WriteLine($"Note: {GetType().Name} is not compatible with {typeof(WorkItemMigrationConfig).Name}");
+            return !otherProcessors.Any(x => x is WorkItemMigrationConfig);
+        }
     }
 }

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemUpdateAreasAsTagsConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemUpdateAreasAsTagsConfig.cs
@@ -1,24 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
     public class WorkItemUpdateAreasAsTagsConfig : ITfsProcessingConfig
     {
-        public bool Enabled { get; set; }
         public string AreaIterationPath { get; set; }
+        public bool Enabled { get; set; }
 
         public Type Processor
         {
-            get
-            {
-                return typeof(WorkItemUpdateAreasAsTagsContext);
-            }
+            get { return typeof(WorkItemUpdateAreasAsTagsContext); }
         }
 
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemUpdateConfig.cs
+++ b/src/VstsSyncMigrator.Core/Configuration/Processing/WorkItemUpdateConfig.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VstsSyncMigrator.Engine.Configuration.Processing
 {
@@ -10,17 +7,19 @@ namespace VstsSyncMigrator.Engine.Configuration.Processing
     {
         public bool WhatIf { get; set; }
 
+        public string QueryBit { get; set; }
+
         public bool Enabled { get; set; }
 
         public Type Processor
         {
-            get
-            {
-                return typeof(WorkItemUpdate);
-            }
+            get { return typeof(WorkItemUpdate); }
         }
 
-        public string QueryBit { get; set; }
+        /// <inheritdoc />
+        public bool IsProcessorCompatible(IReadOnlyList<ITfsProcessingConfig> otherProcessors)
+        {
+            return true;
+        }
     }
-    }
-
+}

--- a/src/VstsSyncMigrator.Core/MigrationEngine.cs
+++ b/src/VstsSyncMigrator.Core/MigrationEngine.cs
@@ -57,12 +57,22 @@ namespace VstsSyncMigrator.Engine
                 Trace.WriteLine(string.Format("Adding Work Item Type {0}", key), "MigrationEngine");
                 this.AddWorkItemTypeDefinition(key, new DescreteWitdMapper(config.WorkItemTypeDefinition[key]));
             }
-            foreach (ITfsProcessingConfig processorConfig in config.Processors)
+            var enabledProcessors = config.Processors.Where(x => x.Enabled).ToList();
+            foreach (ITfsProcessingConfig processorConfig in enabledProcessors)
             {
-                if (processorConfig.Enabled)
+                if (processorConfig.IsProcessorCompatible(enabledProcessors))
                 {
-                    Trace.WriteLine(string.Format("Adding Processor {0}", processorConfig.Processor.Name), "MigrationEngine");
-                    this.AddProcessor((ITfsProcessingContext)Activator.CreateInstance(processorConfig.Processor, this, processorConfig));
+                    Trace.WriteLine($"Adding Processor {processorConfig.Processor.Name}", "MigrationEngine");
+                    this.AddProcessor(
+                        (ITfsProcessingContext)
+                        Activator.CreateInstance(processorConfig.Processor, this, processorConfig));
+                }
+                else
+                {
+                    var message = $"[ERROR] Cannot add Processor {processorConfig.Processor.Name}. " +
+                                  "Processor is not compatible with other enabled processors in configuration.";
+                    Trace.WriteLine(message, "MigrationEngine");
+                    throw new InvalidOperationException(message);
                 }
             }
         }


### PR DESCRIPTION
Including safety check to not allow running WorkItemMigrationContext and WorkItemRevisionReplayMigrationContext at the same time, as they are not "compatible" with each other.